### PR TITLE
Fix Maven failure by updating version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -201,8 +201,8 @@
 					<artifactId>maven-compiler-plugin</artifactId>
 					<version>3.5.1</version>
 					<configuration>
-						<source>1.6</source>
-						<target>1.6</target>
+						<source>1.7</source>
+						<target>1.7</target>
 					</configuration>
 				</plugin>
 				<plugin>


### PR DESCRIPTION
Maven fails with default POM:
[ERROR] Source option 6 is no longer supported. Use 7 or later.

This patch fixes it and the code runs fine.